### PR TITLE
Adding Atoti CE Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Set explicit platform for ARM-based Macbooks
+# Set explicit platform (for ARM-based Macbooks)
 FROM --platform=linux/amd64 python:3.10.13-slim-bookworm
 
 # Copy files to container and set working dir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Set explicit platform for ARM-based Macbooks
+FROM --platform=linux/amd64 python:3.10.13-slim-bookworm
+
+# Install dependencies in container
+RUN apt-get update && \
+    apt-get install -y nodejs graphviz && \
+    pip install atoti \
+                atoti-jupyterlab \
+                atoti-aws \
+                atoti-sql
+                # atoti-directquery-bigquery \
+                # atoti-directquery-clickhouse \
+                # atoti-directquery-databricks \
+                # atoti-directquery-mssql \
+                # atoti-directquery-redshift \
+                # atoti-directquery-snowflake \
+                # atoti-directquery-synapse
+
+# Copy files to container and set working dir
+COPY . /atoti
+WORKDIR /atoti
+
+# Set container executable
+CMD [ "jupyter-lab", "--ip=0.0.0.0", "--allow-root", "--no-browser" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,14 @@
 # Set explicit platform for ARM-based Macbooks
 FROM --platform=linux/amd64 python:3.10.13-slim-bookworm
 
-# Install dependencies in container
-RUN apt-get update && \
-    apt-get install -y nodejs graphviz && \
-    pip install atoti \
-                atoti-jupyterlab \
-                atoti-aws \
-                atoti-sql
-                # atoti-directquery-bigquery \
-                # atoti-directquery-clickhouse \
-                # atoti-directquery-databricks \
-                # atoti-directquery-mssql \
-                # atoti-directquery-redshift \
-                # atoti-directquery-snowflake \
-                # atoti-directquery-synapse
-
 # Copy files to container and set working dir
 COPY . /atoti
 WORKDIR /atoti
+
+# Install dependencies in container (poetry style)
+RUN pip install poetry && \
+    poetry config virtualenvs.create false && \
+    poetry install
 
 # Set container executable
 CMD [ "jupyter-lab", "--ip=0.0.0.0", "--allow-root", "--no-browser" ]

--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ Navigate to our Project Template repository to learn how to implement projects:
 
 ### 🧰 Installation
 
-Docker Container [(docs)](https://www.docker.com/resources/what-container/)
-
-```
-> docker run -p 8888:8888 -p 9092:9092 -it atoti-tutorial
-```
-
 Python package [(docs)](https://docs.atoti.io/latest/getting_started/installation.html#python-package):
 
 ```console

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Navigate to our Project Template repository to learn how to implement projects:
 
 ### 🧰 Installation
 
+Docker Container [(docs)](https://www.docker.com/resources/what-container/)
+
+```
+> docker run -p 8888:8888 -p 9092:9092 -it atoti-tutorial
+```
+
 Python package [(docs)](https://docs.atoti.io/latest/getting_started/installation.html#python-package):
 
 ```console


### PR DESCRIPTION
<!--
Thank you for your contribution.

By opening an issue, you agree with atoti's terms of use and privacy policy available at https://www.atoti.io/terms and https://www.atoti.io/privacy-policy
-->

This PR adds a Dockerfile that developers can use to quickly install and access the notebooks in the Atoti repo. To build and test, you must have Docker installed and execute the following (at the root of the repo):

```
docker build -f Dockerfile -t atoti-tutorial .
docker run -p 8888:8888 -p 9092:9092 -it atoti-tutorial
```

Then go to the URL of the JupyterLab instance port forwarded from within the container.