### PR TITLE
Setting atoti_unlock to False for Notebooks Requiring Licenses

### DIFF
--- a/03-use-cases/01-finance/portfolio-management/cvar-optimizer/main.ipynb
+++ b/03-use-cases/01-finance/portfolio-management/cvar-optimizer/main.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "atoti_unlock = True"
+    "atoti_unlock = False"
    ]
   },
   {

--- a/tests/test_exclusion.txt
+++ b/tests/test_exclusion.txt
@@ -2,6 +2,7 @@
 03-use-cases/01-finance/front-office/pnl-explained
 03-use-cases/01-finance/front-office/real-time-risk
 03-use-cases/01-finance/front-office/real-time-risk
+03-use-cases/01-finance/retail-banking/credit-card-analytics
 03-use-cases/01-finance/risk-management/credit-risk/ifrs9
 03-use-cases/01-finance/risk-management/credit-risk/ifrs9
 03-use-cases/01-finance/risk-management/credit-risk/sa-ccr
@@ -22,6 +23,7 @@
 03-use-cases/01-finance/portfolio-management/alt-data
 03-use-cases/01-finance/portfolio-management/cvar-optimizer
 03-use-cases/01-finance/portfolio-management/optimize-with-constraints
+03-use-cases/01-finance/quantitative-strategy/bucket-analysis
 03-use-cases/02-other-industries/airline-industry
 03-use-cases/02-other-industries/airline-industry
 03-use-cases/02-other-industries/baseball
@@ -61,5 +63,6 @@
 03-use-cases/03-community-fun/burritos
 03-use-cases/03-community-fun/christmas-nyan
 03-use-cases/03-community-fun/monte-carlo-pi
+03-use-cases/03-community-fun/pizza-shop
 03-use-cases/03-community-fun/pokemon
 03-use-cases/03-community-fun/wine-analytics


### PR DESCRIPTION
<!--
Thank you for your contribution.

By opening an issue, you agree with atoti's terms of use and privacy policy available at https://www.atoti.io/terms and https://www.atoti.io/privacy-policy
-->

This PR updates the `atoti_unlock` conditional for notebooks requiring licenses to `False` so that users can run the Atoti CE counterparts.