### PR TITLE
Adding parallel OS testing to GHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: Test
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+
 
 jobs:
   test:
@@ -7,18 +10,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python: ["3.10"]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python: ["3.10.11"]
         node-version: [16.x]
       fail-fast: false
     name: Test on ${{ matrix.os }} with Python ${{ matrix.python }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          architecture: x64
           python-version: ${{ matrix.python }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install libomp
+        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-13' }}
+        run: brew install libomp
 
       - name: Install uv
         run: pip install uv

--- a/tests/execute_notebooks.py
+++ b/tests/execute_notebooks.py
@@ -76,7 +76,7 @@ def execute_notebooks():
         logging.info(f"Starting execution of {notebook}")
         notebook_path = Path(notebook)
         notebook = nbformat.read(notebook_path, as_version=4)
-        ep = ExecutePreprocessor(timeout=300, kernel_name="python3")
+        ep = ExecutePreprocessor(startup_timeout=300, timeout=600, kernel_name="python3")
         ep.preprocess(notebook, {"metadata": {"path": notebook_path.parent}})
         logging.info(f"Execution of {notebook_path} succeed")
 

--- a/tests/execute_notebooks.py
+++ b/tests/execute_notebooks.py
@@ -76,7 +76,9 @@ def execute_notebooks():
         logging.info(f"Starting execution of {notebook}")
         notebook_path = Path(notebook)
         notebook = nbformat.read(notebook_path, as_version=4)
-        ep = ExecutePreprocessor(startup_timeout=300, timeout=600, kernel_name="python3")
+        ep = ExecutePreprocessor(
+            startup_timeout=300, timeout=600, kernel_name="python3"
+        )
         ep.preprocess(notebook, {"metadata": {"path": notebook_path.parent}})
         logging.info(f"Execution of {notebook_path} succeed")
 

--- a/tests/test_exclusion.txt
+++ b/tests/test_exclusion.txt
@@ -1,3 +1,10 @@
+03-use-cases/01-finance/quantitative-strategy/bucket-analysis/main.ipynb
+03-use-cases/01-finance/front-office/cumulative-pnl/main.ipynb
+03-use-cases/01-finance/front-office/cumulative-pnl/main.ipynb
+03-use-cases/01-finance/front-office/pnl-explained/main.ipynb
+03-use-cases/01-finance/insurance/price-elasticity/main.ipynb
+03-use-cases/01-finance/retail-banking/credit-card-analytics/cc_data_processing.ipynb
+03-use-cases/01-finance/retail-banking/credit-card-analytics/main.ipynb
 01-atoti-academy/storytelling-with-atoti/01-Storytelling.ipynb
 01-atoti-academy/storytelling-with-atoti/03-Storytelling.ipynb
 02-technical-guides/atoti-pandas-comparison

--- a/tests/test_exclusion.txt
+++ b/tests/test_exclusion.txt
@@ -1,8 +1,3 @@
-03-use-cases/01-finance/quantitative-strategy/bucket-analysis/main.ipynb
-03-use-cases/01-finance/front-office/cumulative-pnl/main.ipynb
-03-use-cases/01-finance/front-office/cumulative-pnl/main.ipynb
-03-use-cases/01-finance/front-office/pnl-explained/main.ipynb
-03-use-cases/01-finance/insurance/price-elasticity/main.ipynb
 03-use-cases/01-finance/retail-banking/credit-card-analytics/cc_data_processing.ipynb
 03-use-cases/01-finance/retail-banking/credit-card-analytics/main.ipynb
 01-atoti-academy/storytelling-with-atoti/01-Storytelling.ipynb

--- a/uv.lock
+++ b/uv.lock
@@ -1762,7 +1762,7 @@ requires-dist = [
     { name = "textblob", specifier = ">=0.18.0,<1" },
     { name = "treelib", specifier = ">=1.6.4,<2" },
     { name = "tsfresh", specifier = ">=0.20.3,<1" },
-    { name = "watchdog", specifier = ">=5.0.3,<6" },
+    { name = "watchdog", specifier = ">=5.0.3,<7" },
     { name = "wget", specifier = ">=3.2,<4" },
     { name = "xgboost", specifier = ">=2.1.1,<3" },
     { name = "yfinance", specifier = ">=0.2.44,<1" },


### PR DESCRIPTION
<!--
Thank you for your contribution.

By opening an issue, you agree with atoti's terms of use and privacy policy available at https://www.atoti.io/terms and https://www.atoti.io/privacy-policy
-->

This PR updates the GHA pipeline to perform parallel OS testing for linux, macOS (x64 + ARM), and Windows. In addition, I've increased kernel + execution timeouts for notebook testing, and scoped the pipeline to only test short-running academy, technical guide, and finance use case notebooks.