### PR TITLE
Adding slack notification to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,3 +22,10 @@ jobs:
         uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
+     
+      - name: Notify Slack
+        if: success()
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"🎉 New Atoti Notebooks release published: ${{ github.ref_name }}\n📦 View Release: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}\"}" \
+            ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!--
Thank you for your contribution. By opening an issue, you agree with atoti's terms of use and privacy policy available at https://www.atoti.io/terms and https://www.atoti.io/privacy-policy
-->

This PR adds a slack notification that will post to a designated channel when a release is successfully published.